### PR TITLE
Only use bower in Travis CI, make Browserify-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: node_js
 node_js:
   - 0.10

--- a/angular-action.js
+++ b/angular-action.js
@@ -120,5 +120,6 @@
                     });
                 } ]
             };
-        });
+        })
+        .name; // pass back as dependency name
 }));

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "karma": "~0.10.2"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower install",
-    "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+    "test": "./node_modules/.bin/bower install && ./node_modules/.bin/karma start --single-run --browsers PhantomJS"
   },
   "license": "MIT",
   "author": "Nick Matantsev <nick.m@myplanet.com>",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "angular-action",
   "version": "2.0.3",
   "description": "User-submittable actions - reusable view-model directive",
+  "main": "angular-action.js",
   "dependencies": {},
   "devDependencies": {
     "bower": "~1.3",


### PR DESCRIPTION
Should fix #10, since we only need bower for test dev-dependencies.