### PR TITLE
Update karma to run tests on PhantomJS 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "karma-coverage": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-phantomjs-launcher": "~0.1.0",
-    "karma": "~0.10.2"
+    "karma-phantomjs-launcher": "~1.0.0",
+    "karma": "~1.0.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/bower install && ./node_modules/.bin/karma start --single-run --browsers PhantomJS"


### PR DESCRIPTION
PhantomJS 1.x doesn't have `Function.prototype.bind` which latest Angular
seems to be using. And upgrade to the launcher ensures that we use
PhantomJS 2.x

Ref: https://github.com/angular/angular.js/issues/13794